### PR TITLE
feat(cloudflare): provider v5 rewrite

### DIFF
--- a/shared/cloudflare/.terraform.lock.hcl
+++ b/shared/cloudflare/.terraform.lock.hcl
@@ -2,18 +2,18 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/cloudflare/cloudflare" {
-  version     = "5.12.0"
+  version     = "5.21.0"
   constraints = "~> 5.0"
   hashes = [
-    "h1:vrbI9qWFMZPA47W+OLnqcBT7+3gk24vfqj5kzoOAyMU=",
-    "zh:06166a72e69eb712ad2c8b49c1ed060223b0d57bb95ce5f6c8440ce19253913e",
-    "zh:484c32dc4fbe1f7baaf00f8d0d1774d259e1a602aebf60b8dea8c6dd122c1d27",
-    "zh:914b4796a5f2c5914cb94864a7541ce132c0e287bf49a5328706d50152117bc4",
-    "zh:bbcf3effe11ad44988c2aa4482c3fd0089ca86527463a9a873cecda1a4a022bc",
-    "zh:c2a59f29b4b4c0344dbb9ab3d78ebcc1d32153f1fd7e919eba7edf7d825119c2",
-    "zh:d6900b39b9c58743e6b1f05b2db7c39276c94f74d501f23bebb88d413266c57c",
-    "zh:f000d33075c30e616df8e58e341614e958eed4a51f3427d2e1a18ea1b7e0c6c6",
+    "h1:TJQJrskWa1FJ8gk6BAhj4X6fa5TFqI255T6Y6ZKrFkU=",
+    "zh:2d3dc17f27dcf308f52bdede3b7bb00e6cda6c1a9fbdafd1bfe4a915e75fdc44",
+    "zh:413e3569ad0cc89f8ac425d8a197d9e892ff356ac24dedde386820cf5880a48e",
+    "zh:59f262b9af9a8845afeb2734a6bd83b260aa2c521e5c318850745823ef62b38d",
+    "zh:7d42963a47ff6dda8aada0cb73a26eb6807c7ff6bb4419cb91b32ce2412c8362",
+    "zh:89cad3906c9affa0f2947607d316d70c38541c399d0519ebee1f1ccc8aaf5675",
+    "zh:d5c7ff6c39d895e5746fed74ecc3f284c91c8c1f502da2e93f5c581f41f87f25",
+    "zh:dc425b5f40e94165e563dc55bd6e49cedfe879a03e668168610459ef071b1a87",
+    "zh:f0665907dd24ae93f9511216052d653bba0823c933e888cf02a4abf95f73dfe0",
     "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
-    "zh:ff4fd5b3b0327f8f41fc65d909839288fb98ecfe32a9aff11d2e2638f2109302",
   ]
 }

--- a/shared/cloudflare/backend.tf
+++ b/shared/cloudflare/backend.tf
@@ -1,8 +1,6 @@
-# Terraform Cloud Backend Configuration
-
 terraform {
-  backend "remote" {
-    organization = "dieu"
+  cloud {
+    organization = "dieubernetes"
     workspaces {
       name = "cloudflare"
     }

--- a/shared/cloudflare/main.tf
+++ b/shared/cloudflare/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.10"
   required_providers {
     cloudflare = {
       source  = "cloudflare/cloudflare"
@@ -8,84 +8,52 @@ terraform {
   }
 }
 
-# Configure Cloudflare provider
-provider "cloudflare" {
-  api_token = var.cloudflare_api_token
-}
+provider "cloudflare" {}
 
-# Create DNS zone for your domain
-resource "cloudflare_zone" "main" {
-  account = var.cloudflare_account_id
-  name    = var.domain_name
-}
-
-# Create DNS records for production
-resource "cloudflare_record" "prod_main" {
-  zone_id = cloudflare_zone.main.id
-  name    = "@"
-  value   = var.prod_load_balancer_ip
-  type    = "A"
-  ttl     = 300
-  proxied = true
-}
-
-resource "cloudflare_record" "prod_www" {
-  zone_id = cloudflare_zone.main.id
-  name    = "www"
-  value   = var.domain_name
-  type    = "CNAME"
-  ttl     = 300
-  proxied = true
-}
-
-resource "cloudflare_record" "prod_api" {
-  zone_id = cloudflare_zone.main.id
-  name    = "api"
-  value   = var.prod_api_gateway_ip
-  type    = "A"
-  ttl     = 300
-  proxied = true
-}
-
-# Create DNS records for staging
-resource "cloudflare_record" "stage_main" {
-  zone_id = cloudflare_zone.main.id
-  name    = "stage"
-  value   = var.stage_load_balancer_ip
-  type    = "A"
-  ttl     = 300
-  proxied = true
-}
-
-resource "cloudflare_record" "stage_api" {
-  zone_id = cloudflare_zone.main.id
-  name    = "api-stage"
-  value   = var.stage_api_gateway_ip
-  type    = "A"
-  ttl     = 300
-  proxied = true
-}
-
-# Configure Cloudflare settings for performance and security
-resource "cloudflare_zone_settings_override" "main" {
-  zone_id = cloudflare_zone.main.id
-
-  settings {
-    ssl                      = "full"
-    min_tls_version          = "1.2"
-    security_level           = "medium"
-    always_use_https        = "on"
-    automatic_https_rewrites = "on"
-    browser_check           = "on"
-    challenge_ttl           = 1800
-    privacy_pass           = "on"
-    websockets             = "on"
-    opportunistic_encryption = "on"
-    tls_1_3               = "on"
-    minify {
-      css  = "on"
-      html = "on"
-      js   = "on"
-    }
+data "cloudflare_zone" "main" {
+  filter = {
+    name = var.zone_name
   }
+}
+
+data "terraform_remote_state" "primary_cluster" {
+  backend = "remote"
+  config = {
+    organization = "dieubernetes"
+    workspaces = { name = var.primary_cluster_workspace }
+  }
+}
+
+locals {
+  lb_ip = data.terraform_remote_state.primary_cluster.outputs.lb_ip
+}
+
+# Apex A — proxied; always derived from primary cluster state, never hardcoded
+resource "cloudflare_dns_record" "apex" {
+  zone_id = data.cloudflare_zone.main.id
+  name    = "@"
+  type    = "A"
+  content = local.lb_ip
+  proxied = true
+  ttl     = 1
+}
+
+# www CNAME → apex
+resource "cloudflare_dns_record" "www" {
+  zone_id = data.cloudflare_zone.main.id
+  name    = "www"
+  type    = "CNAME"
+  content = var.zone_name
+  proxied = true
+  ttl     = 1
+}
+
+# argocd — not proxied so cert-manager HTTP-01 challenges reach the cluster directly
+resource "cloudflare_dns_record" "argocd" {
+  zone_id = data.cloudflare_zone.main.id
+  name    = "argocd"
+  type    = "A"
+  content = local.lb_ip
+  proxied = false
+  ttl     = 1
 }

--- a/shared/cloudflare/outputs.tf
+++ b/shared/cloudflare/outputs.tf
@@ -1,24 +1,7 @@
 output "zone_id" {
-  description = "Cloudflare zone ID"
-  value       = cloudflare_zone.main.id
+  value = data.cloudflare_zone.main.id
 }
 
 output "zone_name" {
-  description = "Cloudflare zone name"
-  value       = cloudflare_zone.main.name
-}
-
-output "name_servers" {
-  description = "Cloudflare name servers for the zone"
-  value       = cloudflare_zone.main.name_servers
-}
-
-output "prod_main_record" {
-  description = "Production main DNS record"
-  value       = cloudflare_record.prod_main.hostname
-}
-
-output "stage_main_record" {
-  description = "Staging main DNS record"
-  value       = cloudflare_record.stage_main.hostname
+  value = data.cloudflare_zone.main.name
 }

--- a/shared/cloudflare/variables.tf
+++ b/shared/cloudflare/variables.tf
@@ -1,39 +1,15 @@
-variable "cloudflare_api_token" {
-  description = "Cloudflare API token"
-  type        = string
-  sensitive   = true
-}
-
 variable "cloudflare_account_id" {
   description = "Cloudflare account ID"
   type        = string
 }
 
-variable "domain_name" {
-  description = "Your domain name (e.g., example.com)"
+variable "zone_name" {
+  description = "Cloudflare zone name"
   type        = string
+  default     = "dieu.dev"
 }
 
-variable "prod_load_balancer_ip" {
-  description = "Production load balancer IP address"
+variable "primary_cluster_workspace" {
+  description = "TFC workspace name of the active platform cluster — apex and argocd DNS point at its lb_ip"
   type        = string
-  default     = ""
-}
-
-variable "prod_api_gateway_ip" {
-  description = "Production API gateway IP address"
-  type        = string
-  default     = ""
-}
-
-variable "stage_load_balancer_ip" {
-  description = "Staging load balancer IP address"
-  type        = string
-  default     = ""
-}
-
-variable "stage_api_gateway_ip" {
-  description = "Staging API gateway IP address"
-  type        = string
-  default     = ""
 }


### PR DESCRIPTION
Rewrites shared/cloudflare for the v5 provider: cloudflare_dns_record instead of cloudflare_record, zone as a data source, LB IP sourced from prod-doks remote state instead of a hardcoded variable.

No apply run as part of this PR since DNS changes go out in a separate, deliberate step.