### PR TITLE
ci: add terraform fmt/validate/tflint checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+on:
+  pull_request:
+
+jobs:
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.15.6
+      - run: terraform fmt -check -recursive
+
+  validate:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        workspace:
+          - clusters/dieubernetes-platform-do-atl1
+          - shared/cloudflare
+          - shared/failover
+          - modules/digitalocean/doks-cluster
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.15.6
+      - name: Init
+        working-directory: ${{ matrix.workspace }}
+        run: terraform init -backend=false
+      - name: Validate
+        working-directory: ${{ matrix.workspace }}
+        run: terraform validate
+
+  tflint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: terraform-linters/setup-tflint@v4
+      - run: tflint --recursive


### PR DESCRIPTION
Adds a CI workflow running terraform fmt -check, terraform validate (across
clusters/dieubernetes-platform-do-atl1, shared/cloudflare, shared/failover,
modules/digitalocean/doks-cluster), and tflint on every PR.

Stacked on #5 — the validated workspace paths only exist on that branch's history.

Refs #8 — groundwork for plan-on-PR; this PR doesn't post a plan diff yet.